### PR TITLE
Refactor uses of pointer-to-interface & append

### DIFF
--- a/formatted.go
+++ b/formatted.go
@@ -120,7 +120,7 @@ func (f Formatted) String() string {
 	return out + ")"
 }
 
-func (f Formatted) Ok(db *UserDatabase) bool {
+func (f Formatted) Ok(db UserDatabase) bool {
 	// Goes through the smallest number of conditions possible to check if the
 	// threshold gate returns true.  Sometimes requires recursing down to check
 	// nested threshold gates.

--- a/formatted.go
+++ b/formatted.go
@@ -109,11 +109,11 @@ func (f Formatted) String() string {
 	out := fmt.Sprintf("(%v", f.Min)
 
 	for _, cond := range f.Conds {
-		switch cond.(type) {
+		switch cond := cond.(type) {
 		case Name:
-			out += fmt.Sprintf(", %v", cond.(Name).string)
+			out += fmt.Sprintf(", %v", cond.string)
 		case Formatted:
-			out += fmt.Sprintf(", %v", (cond.(Formatted)).String())
+			out += fmt.Sprintf(", %v", cond.String())
 		}
 	}
 
@@ -149,9 +149,8 @@ func (f *Formatted) Compress() {
 				continue
 			}
 
-			switch cond.(type) {
+			switch cond := cond.(type) {
 			case Formatted:
-				cond := cond.(Formatted)
 				cond.Compress()
 				f.Conds[i] = cond
 
@@ -172,9 +171,8 @@ func (f *Formatted) Compress() {
 				continue
 			}
 
-			switch cond.(type) {
+			switch cond := cond.(type) {
 			case Formatted:
-				cond := cond.(Formatted)
 				cond.Compress()
 				f.Conds[i] = cond
 

--- a/formatted_test.go
+++ b/formatted_test.go
@@ -45,24 +45,24 @@ func TestFormatted(t *testing.T) {
 		},
 	}
 
-	db := UserDatabase(Database(map[string][][]byte{
+	db := &Database{
 		"Alice": [][]byte{[]byte("blah")},
 		"Carl":  [][]byte{[]byte("herp")},
-	}))
+	}
 
-	if query1.Ok(&db) != true {
+	if query1.Ok(db) != true {
 		t.Fatalf("Query #1 was wrong.")
 	}
 
-	if query2.Ok(&db) != false {
+	if query2.Ok(db) != false {
 		t.Fatalf("Query #2 was wrong.")
 	}
 
-	if query3.Ok(&db) != true {
+	if query3.Ok(db) != true {
 		t.Fatalf("Query #3 was wrong.")
 	}
 
-	if query4.Ok(&db) != false {
+	if query4.Ok(db) != false {
 		t.Fatalf("Query #4 was wrong.")
 	}
 

--- a/msp.go
+++ b/msp.go
@@ -190,14 +190,11 @@ func (m MSP) DistributeShares(sec []byte, db UserDatabase) (map[string][][]byte,
 		switch cond.(type) {
 		case Name:
 			name := cond.(Name).string
-			if _, ok := out[name]; ok {
-				out[name] = append(out[name], share)
-			} else if db.ValidUser(name) {
-				out[name] = [][]byte{share}
-			} else {
-				return out, errors.New("Unknown user in predicate.")
+			if !db.ValidUser(name) {
+				return nil, errors.New("Unknown user in predicate.")
 			}
 
+			out[name] = append(out[name], share)
 		default:
 			below := MSP(cond.(Formatted))
 			subOut, err := below.DistributeShares(share, db)
@@ -206,12 +203,7 @@ func (m MSP) DistributeShares(sec []byte, db UserDatabase) (map[string][][]byte,
 			}
 
 			for name, shares := range subOut {
-				if _, ok := out[name]; ok {
-					out[name] = append(out[name], shares...)
-				} else {
-					out[name] = shares
-				}
-
+				out[name] = append(out[name], shares...)
 			}
 		}
 	}

--- a/msp.go
+++ b/msp.go
@@ -124,18 +124,18 @@ func (m MSP) DerivePath(db UserDatabase) (ok bool, names []string, locs []int, t
 	ts := &TraceSlice{}
 
 	for i, cond := range m.Conds {
-		switch cond.(type) {
+		switch cond := cond.(type) {
 		case Name:
-			if db.CanGetShare(cond.(Name).string) {
+			if db.CanGetShare(cond.string) {
 				heap.Push(ts, TraceElem{
 					i,
-					[]string{cond.(Name).string},
-					[]string{cond.(Name).string},
+					[]string{cond.string},
+					[]string{cond.string},
 				})
 			}
 
 		case Formatted:
-			sok, _, _, strace := MSP(cond.(Formatted)).DerivePath(db)
+			sok, _, _, strace := MSP(cond).DerivePath(db)
 			if sok {
 				heap.Push(ts, TraceElem{i, []string{}, strace})
 			}
@@ -187,16 +187,16 @@ func (m MSP) DistributeShares(sec []byte, db UserDatabase) (map[string][][]byte,
 	for i, cond := range m.Conds {
 		share := shares[i]
 
-		switch cond.(type) {
+		switch cond := cond.(type) {
 		case Name:
-			name := cond.(Name).string
+			name := cond.string
 			if !db.ValidUser(name) {
 				return nil, errors.New("Unknown user in predicate.")
 			}
 
 			out[name] = append(out[name], share)
-		default:
-			below := MSP(cond.(Formatted))
+		case Formatted:
+			below := MSP(cond)
 			subOut, err := below.DistributeShares(share, db)
 			if err != nil {
 				return out, err
@@ -243,16 +243,16 @@ func (m MSP) recoverSecret(db UserDatabase, cache map[string][][]byte) ([]byte, 
 		gate := m.Conds[loc]
 		index = append(index, loc+1)
 
-		switch gate.(type) {
+		switch gate := gate.(type) {
 		case Name:
-			if len(cache[gate.(Name).string]) <= gate.(Name).index {
+			if len(cache[gate.string]) <= gate.index {
 				return nil, errors.New("Predicate / database mismatch!")
 			}
 
-			shares = append(shares, FieldElem(cache[gate.(Name).string][gate.(Name).index]))
+			shares = append(shares, FieldElem(cache[gate.string][gate.index]))
 
 		case Formatted:
-			share, err := MSP(gate.(Formatted)).recoverSecret(db, cache)
+			share, err := MSP(gate).recoverSecret(db, cache)
 			if err != nil {
 				return nil, err
 			}

--- a/msp_test.go
+++ b/msp_test.go
@@ -9,18 +9,18 @@ import (
 
 type Database map[string][][]byte
 
-func (d Database) ValidUser(name string) bool {
-	_, ok := d[name]
+func (d *Database) ValidUser(name string) bool {
+	_, ok := (*d)[name]
 	return ok
 }
 
-func (d Database) CanGetShare(name string) bool {
-	_, ok := d[name]
+func (d *Database) CanGetShare(name string) bool {
+	_, ok := (*d)[name]
 	return ok
 }
 
-func (d Database) GetShare(name string) ([][]byte, error) {
-	out, ok := d[name]
+func (d *Database) GetShare(name string) ([][]byte, error) {
+	out, ok := (*d)[name]
 
 	if ok {
 		return out, nil
@@ -30,11 +30,11 @@ func (d Database) GetShare(name string) ([][]byte, error) {
 }
 
 func TestMSP(t *testing.T) {
-	db := UserDatabase(Database(map[string][][]byte{
+	db := &Database{
 		"Alice": [][]byte{},
 		"Bob":   [][]byte{},
 		"Carl":  [][]byte{},
-	}))
+	}
 
 	sec := make([]byte, 16)
 	rand.Read(sec)
@@ -42,8 +42,8 @@ func TestMSP(t *testing.T) {
 
 	predicate, _ := StringToMSP("(2, (1, Alice, Bob), Carl)")
 
-	shares1, _ := predicate.DistributeShares(sec, &db)
-	shares2, _ := predicate.DistributeShares(sec, &db)
+	shares1, _ := predicate.DistributeShares(sec, db)
+	shares2, _ := predicate.DistributeShares(sec, db)
 
 	alice := bytes.Compare(shares1["Alice"][0], shares2["Alice"][0])
 	bob := bytes.Compare(shares1["Bob"][0], shares2["Bob"][0])
@@ -53,8 +53,8 @@ func TestMSP(t *testing.T) {
 		t.Fatalf("Key splitting isn't random! %v %v", shares1, shares2)
 	}
 
-	db1 := UserDatabase(Database(shares1))
-	db2 := UserDatabase(Database(shares2))
+	db1 := Database(shares1)
+	db2 := Database(shares2)
 
 	sec1, err := predicate.RecoverSecret(&db1)
 	if err != nil {

--- a/raw.go
+++ b/raw.go
@@ -135,9 +135,9 @@ func StringToRaw(r string) (out Raw, err error) {
 				if len(r) == 0 {
 					res := top[0].Front().Value
 
-					switch res.(type) {
+					switch res := res.(type) {
 					case Raw:
-						return res.(Raw), nil
+						return res, nil
 					default:
 						return out, errors.New("Invalid string: Only one condition was found.")
 					}
@@ -166,11 +166,11 @@ func StringToRaw(r string) (out Raw, err error) {
 func (r Raw) String() string {
 	out := ""
 
-	switch r.Left.(type) {
+	switch left := r.Left.(type) {
 	case Name:
-		out += r.Left.(Name).string
-	default:
-		out += "(" + r.Left.(Raw).String() + ")"
+		out += left.string
+	case Raw:
+		out += "(" + left.String() + ")"
 	}
 
 	if r.Type() == NodeAnd {
@@ -179,11 +179,11 @@ func (r Raw) String() string {
 		out += " | "
 	}
 
-	switch r.Right.(type) {
+	switch right := r.Right.(type) {
 	case Name:
-		out += r.Right.(Name).string
-	default:
-		out += "(" + r.Right.(Raw).String() + ")"
+		out += right.string
+	case Raw:
+		out += "(" + right.String() + ")"
 	}
 
 	return out
@@ -198,18 +198,18 @@ func (r Raw) Formatted() (out Formatted) {
 		out.Min = 1
 	}
 
-	switch r.Left.(type) {
+	switch left := r.Left.(type) {
 	case Name:
-		out.Conds = []Condition{r.Left.(Name)}
-	default:
-		out.Conds = []Condition{r.Left.(Raw).Formatted()}
+		out.Conds = []Condition{left}
+	case Raw:
+		out.Conds = []Condition{left.Formatted()}
 	}
 
-	switch r.Right.(type) {
+	switch right := r.Right.(type) {
 	case Name:
-		out.Conds = append(out.Conds, r.Right.(Name))
-	default:
-		out.Conds = append(out.Conds, r.Right.(Raw).Formatted())
+		out.Conds = append(out.Conds, right)
+	case Raw:
+		out.Conds = append(out.Conds, right.Formatted())
 	}
 
 	out.Compress() // Small amount of predicate compression.

--- a/raw.go
+++ b/raw.go
@@ -20,8 +20,8 @@ func (t NodeType) Type() NodeType {
 type Raw struct { // Represents one node in the tree.
 	NodeType
 
-	Left  *Condition
-	Right *Condition
+	Left  Condition
+	Right Condition
 }
 
 func StringToRaw(r string) (out Raw, err error) {
@@ -113,8 +113,8 @@ func StringToRaw(r string) (out Raw, err error) {
 
 						leftOperand.Next().Value = Raw{
 							NodeType: typ,
-							Left:     &left,
-							Right:    &right,
+							Left:     left,
+							Right:    right,
 						}
 
 						leftOperand = leftOperand.Next()
@@ -166,11 +166,11 @@ func StringToRaw(r string) (out Raw, err error) {
 func (r Raw) String() string {
 	out := ""
 
-	switch (*r.Left).(type) {
+	switch r.Left.(type) {
 	case Name:
-		out += (*r.Left).(Name).string
+		out += r.Left.(Name).string
 	default:
-		out += "(" + (*r.Left).(Raw).String() + ")"
+		out += "(" + r.Left.(Raw).String() + ")"
 	}
 
 	if r.Type() == NodeAnd {
@@ -179,11 +179,11 @@ func (r Raw) String() string {
 		out += " | "
 	}
 
-	switch (*r.Right).(type) {
+	switch r.Right.(type) {
 	case Name:
-		out += (*r.Right).(Name).string
+		out += r.Right.(Name).string
 	default:
-		out += "(" + (*r.Right).(Raw).String() + ")"
+		out += "(" + r.Right.(Raw).String() + ")"
 	}
 
 	return out
@@ -198,28 +198,28 @@ func (r Raw) Formatted() (out Formatted) {
 		out.Min = 1
 	}
 
-	switch (*r.Left).(type) {
+	switch r.Left.(type) {
 	case Name:
-		out.Conds = []Condition{(*r.Left).(Name)}
+		out.Conds = []Condition{r.Left.(Name)}
 	default:
-		out.Conds = []Condition{(*r.Left).(Raw).Formatted()}
+		out.Conds = []Condition{r.Left.(Raw).Formatted()}
 	}
 
-	switch (*r.Right).(type) {
+	switch r.Right.(type) {
 	case Name:
-		out.Conds = append(out.Conds, (*r.Right).(Name))
+		out.Conds = append(out.Conds, r.Right.(Name))
 	default:
-		out.Conds = append(out.Conds, (*r.Right).(Raw).Formatted())
+		out.Conds = append(out.Conds, r.Right.(Raw).Formatted())
 	}
 
 	out.Compress() // Small amount of predicate compression.
 	return
 }
 
-func (r Raw) Ok(db *UserDatabase) bool {
+func (r Raw) Ok(db UserDatabase) bool {
 	if r.Type() == NodeAnd {
-		return (*r.Left).Ok(db) && (*r.Right).Ok(db)
+		return r.Left.Ok(db) && r.Right.Ok(db)
 	} else {
-		return (*r.Left).Ok(db) || (*r.Right).Ok(db)
+		return r.Left.Ok(db) || r.Right.Ok(db)
 	}
 }

--- a/raw_test.go
+++ b/raw_test.go
@@ -11,32 +11,32 @@ func TestRaw(t *testing.T) {
 
 	query1 := Raw{
 		NodeType: NodeAnd,
-		Left:     &alice,
-		Right:    &bob,
+		Left:     alice,
+		Right:    bob,
 	}
 
 	aliceOrBob := Condition(Raw{
 		NodeType: NodeOr,
-		Left:     &alice,
-		Right:    &bob,
+		Left:     alice,
+		Right:    bob,
 	})
 
 	query2 := Raw{
 		NodeType: NodeAnd,
-		Left:     &aliceOrBob,
-		Right:    &carl,
+		Left:     aliceOrBob,
+		Right:    carl,
 	}
 
-	db := UserDatabase(Database(map[string][][]byte{
+	db := &Database{
 		"Alice": [][]byte{[]byte("blah")},
 		"Carl":  [][]byte{[]byte("herp")},
-	}))
+	}
 
-	if query1.Ok(&db) != false {
+	if query1.Ok(db) != false {
 		t.Fatalf("Query #1 was wrong.")
 	}
 
-	if query2.Ok(&db) != true {
+	if query2.Ok(db) != true {
 		t.Fatalf("Query #2 was wrong.")
 	}
 


### PR DESCRIPTION
Switch *UserDatabase & *Condition arguments to UserDatabase & Condition to avoid [pointer-to-interface](https://golang.org/doc/faq#pointer_to_interface) arguments. And remove an unnecessary `nil` check before calling `append`.
